### PR TITLE
Make JSON_API_CONTROLLERS really set default controllers

### DIFF
--- a/controllers/core.php
+++ b/controllers/core.php
@@ -27,7 +27,7 @@ class JSON_API_Core_Controller {
       } else {
         $version = '(Unknown)';
       }
-      $active_controllers = explode(',', get_option('json_api_controllers', 'core'));
+      $active_controllers = $json_api->get_active_controllers();
       $controllers = array_intersect($json_api->get_controllers(), $active_controllers);
       return array(
         'json_api_version' => $version,

--- a/singletons/api.php
+++ b/singletons/api.php
@@ -16,7 +16,7 @@ class JSON_API {
     // Check to see if there's an appropriate API controller + method    
     $controller = strtolower($this->query->get_controller());
     $available_controllers = $this->get_controllers();
-    $enabled_controllers = explode(',', get_option('json_api_controllers', 'core'));
+    $enabled_controllers = $this->get_active_controllers();
     $active_controllers = array_intersect($available_controllers, $enabled_controllers);
     
     if ($controller) {
@@ -72,7 +72,7 @@ class JSON_API {
     }
     
     $available_controllers = $this->get_controllers();
-    $active_controllers = explode(',', get_option('json_api_controllers', 'core'));
+    $active_controllers = $this->get_active_controllers();
     
     if (count($active_controllers) == 1 && empty($active_controllers[0])) {
       $active_controllers = array();
@@ -284,14 +284,18 @@ class JSON_API {
     $controllers = apply_filters('json_api_controllers', $controllers);
     return array_map('strtolower', $controllers);
   }
-  
-  function controller_is_active($controller) {
+
+  function get_active_controllers() {
     if (defined('JSON_API_CONTROLLERS')) {
       $default = JSON_API_CONTROLLERS;
     } else {
       $default = 'core';
     }
-    $active_controllers = explode(',', get_option('json_api_controllers', $default));
+    return explode(',', get_option('json_api_controllers', $default));
+  }
+  
+  function controller_is_active($controller) {
+    $active_controllers = $this->get_active_controllers();
     return (in_array($controller, $active_controllers));
   }
   


### PR DESCRIPTION
JSON_API_CONTROLLERS didn't seem to enable the external controllers I made. 

Sorry I was too lazy to run the test suite, it may fail. 
