### PR TITLE
Only 5 child pages are returned for get_page/get_page_index methods

### DIFF
--- a/singletons/introspector.php
+++ b/singletons/introspector.php
@@ -232,7 +232,8 @@ class JSON_API_Introspector {
       'post_type' => $post->type,
       'post_parent' => $post->id,
       'order' => 'ASC',
-      'orderby' => 'menu_order'
+      'orderby' => 'menu_order',
+      'numberposts' => -1
     ));
     foreach ($wp_children as $wp_post) {
       $post->children[] = new JSON_API_Post($wp_post);


### PR DESCRIPTION
It looks like support for the `numberposts` parameter needs to be added when using the `attach_child_posts` introspector (which calls [get_posts](http://codex.wordpress.org/Template_Tags/get_posts)) when using the `get_page` and `get_page_index` methods. The `get_page_index` method supports a `count` argument whose value is passed to the `get_posts` introspector there, but it also doesn't have an affect on children.
