### PR TITLE
Added meta data and date settings at post creation

### DIFF
--- a/models/post.php
+++ b/models/post.php
@@ -112,6 +112,13 @@ class JSON_API_Post {
     } else {
       $this->id = wp_insert_post($wp_values);
     }
+
+	if (isset($values['meta'])) {
+      $meta = $values['meta'];
+      foreach ($meta as $meta_key => $meta_value) {
+		 update_post_meta($this->id, $meta_key, $meta_value);
+      }
+    }
     
     if (!empty($_FILES['attachment'])) {
       include_once ABSPATH . '/wp-admin/includes/file.php';


### PR DESCRIPTION
Added the parameters 'date' and 'meta' to the 'create_post' function.
- The parameter is mapped to 'post_date' in Wordpress.
- The parameter 'meta' contains an array of 'key' => 'value'. The Wordpress function 'update_post_meta' is called for each pair at post creation.
