### PR TITLE
Correct headers update

### DIFF
--- a/singletons/api.php
+++ b/singletons/api.php
@@ -356,7 +356,7 @@ class JSON_API {
     $wp_rewrite->flush_rules();
   }
   
-  function error($message = 'Unknown error', $status = 'error', $header = '200 OK') {
+  function error($message = 'Unknown error', $status = 'error', $header = '400') {
     $this->response->respond(array(
       'error' => $message
     ), $status, $header);

--- a/singletons/api.php
+++ b/singletons/api.php
@@ -356,10 +356,10 @@ class JSON_API {
     $wp_rewrite->flush_rules();
   }
   
-  function error($message = 'Unknown error', $status = 'error') {
+  function error($message = 'Unknown error', $status = 'error', $header = '200 OK') {
     $this->response->respond(array(
       'error' => $message
-    ), $status);
+    ), $status, $header);
   }
   
   function include_value($key) {

--- a/singletons/response.php
+++ b/singletons/response.php
@@ -57,7 +57,7 @@ class JSON_API_Response {
     }
   }
   
-  function respond($result, $status = 'ok') {
+  function respond($result, $status = 'ok', $header) {
     global $json_api;
     $json = $this->get_json($result, $status);
     $status_redirect = "redirect_$status";
@@ -80,15 +80,15 @@ class JSON_API_Response {
       $this->callback($json_api->query->callback, $json);
     } else {
       // Output the result
-      $this->output($json);
+      $this->output($json, $header);
     }
     exit;
   }
   
-  function output($result) {
+  function output($result, $header) {
     $charset = get_option('blog_charset');
     if (!headers_sent()) {
-      header('HTTP/1.1 200 OK', true);
+      header("HTTP/1.1 ${$header}", true);
       header("Content-Type: application/json; charset=$charset", true);
     }
     echo $result;


### PR DESCRIPTION
I've added some functionality to error method in API.php and output, response in response.php
This might look ugly but the Idea is to have certain headers to be served when wrong syntax used in queries or authentication has failed. 

Currently there's only 200 which is pretty annoying when working with backbone.js

Please feel free to criticize my code I am new to PHP and will fix it accordingly.

Proposed code is working at http://nuwaxrecords.com/api/
400 http://www.nuwaxrecords.com/api/get_nonce/
