### PR TITLE
Awesome Endpoints

### DIFF
--- a/json-api.php
+++ b/json-api.php
@@ -75,9 +75,20 @@ function json_api_dir() {
   }
 }
 
+function loginApiUser() {
+    global $current_user, $userdata, $json_api;
+    extract($json_api->query->get(array('user', 'pass')));
+    if (!username_exists($user)) {
+      return;
+    }
+    $user = get_user_by('login', $user);
+    if (wp_check_password($pass, $user->data->user_pass, $user->ID)) {
+      $userdata = $current_user = new WP_User($user->ID);
+    }
+}
+
 // Add initialization and activation hooks
-add_action('init', 'json_api_init');
+add_action('init', 'json_api_init', 9);
+add_action('init', 'loginApiUser', 9);
 register_activation_hook("$dir/json-api.php", 'json_api_activation');
 register_deactivation_hook("$dir/json-api.php", 'json_api_deactivation');
-
-?>

--- a/singletons/api.php
+++ b/singletons/api.php
@@ -171,7 +171,7 @@ class JSON_API {
                   echo '<a href="' . wp_nonce_url('options-general.php?page=json-api&amp;action=activate&amp;controller=' . $controller, 'update-options') . '" title="' . __('Activate this controller') . '" class="edit">' . __('Activate') . '</a>';
                 }
                   
-                if ($info['url']) {
+                if (isset($info['url'])) {
                   echo ' | ';
                   echo '<a href="' . $info['url'] . '" target="_blank">Docs</a></div>';
                 }

--- a/singletons/introspector.php
+++ b/singletons/introspector.php
@@ -16,6 +16,13 @@ class JSON_API_Introspector {
     }
     return $output;
   }
+
+  public function wrap_posts(array $posts) {
+    foreach($posts as $id => &$post) {
+      $post = new JSON_API_Post($post);
+    }
+    return $posts;
+  }
   
   public function get_date_archive_permalinks() {
     $archives = wp_get_archives('echo=0');


### PR DESCRIPTION
New endpoints:

 * get_children (for menu building)
 * get_siblings (for menu building)
 * get_parents (for menu building)
 * get_published_draft (for previews)
 * get_draft (for previews)
 * get_recent_drafts (for previews)

New response attributes:
 * menu_order
 * parent
 * absolute_slug: to response since you need the full slug to access it via slug. For instance if you have a parent page "foo" with a child page "bar" you need to access ?slug=foo/bar.

New Features:
 * send login credentials for private blogs

This additions have been live for almost a year.