### PR TITLE
Fix ABSPATH usage.

### DIFF
--- a/models/attachment.php
+++ b/models/attachment.php
@@ -42,17 +42,17 @@ class JSON_API_Attachment {
     }
     $this->images = array();
     $home = get_bloginfo('url');
-    foreach ($sizes as $size) {
-      list($url, $width, $height) = wp_get_attachment_image_src($this->id, $size);
-      $filename = ABSPATH . substr($url, strlen($home) + 1);
+    $attachment = wp_get_attachment_metadata($this->id);
+    foreach ($attachment['sizes'] as $size => $data) {
+      $filename = WP_CONTENT_DIR . '/uploads/' . pathinfo($attachment['file'])['dirname'] . '/' . $data['file'];
       if (file_exists($filename)) {
         list($measured_width, $measured_height) = getimagesize($filename);
-        if ($measured_width == $width &&
-            $measured_height == $height) {
+        if ($measured_width == $data['width'] &&
+            $measured_height == $data['height']) {
           $this->images[$size] = (object) array(
-            'url' => $url,
-            'width' => $width,
-            'height' => $height
+            'url' => wp_get_attachment_image_src($this->id, $size)[0],
+            'width' => $data['width'],
+            'height' => $data['height']
           );
         }
       }


### PR DESCRIPTION
This was required for usecases where wp-content is not in a child directory of the wordpress directory (i.e. https://github.com/roots/bedrock)

The problem was that the old method returned a path like `/var/www/public/wp/app/uploads/...` whereas theneeded path was `/var/www/public/app/uploads/...`
