### PR TITLE
Fixed query_images() for compatibility with Plugin "WP-Offload-S3"

### DIFF
--- a/models/attachment.php
+++ b/models/attachment.php
@@ -34,7 +34,7 @@ class JSON_API_Attachment {
   function is_image() {
     return (substr($this->mime_type, 0, 5) == 'image');
   }
-
+  
   function query_images() {
     $sizes = array('thumbnail', 'medium', 'large', 'full');
     if (function_exists('get_intermediate_image_sizes')) {
@@ -42,39 +42,19 @@ class JSON_API_Attachment {
     }
     $this->images = array();
     $home = get_bloginfo('url');
-    $hostOfHome = parse_url($home, PHP_URL_HOST);
     foreach ($sizes as $size) {
-
       list($url, $width, $height) = wp_get_attachment_image_src($this->id, $size);
-
-      // changelog 2016-01-13 from @itinance https://github.com/itinance:
-      //
-      // if plugin "WP-Offload-S3" is installed, the attachments are stored at s3/cloudfront and not necessarily
-      // hosted on the server beeing available at ABSPATH. In this case, let us trust the result
-      // of wp_get_attachment_image_src() and renounce calls to file_exists() and getimagesize()
-
-      $hostOfAttachment = parse_url($url, PHP_URL_HOST);
-      if($hostOfAttachment === $hostOfHome) {
-        $filename = ABSPATH . substr($url, strlen($home) + 1);
-        if (file_exists($filename)) {
-          list($measured_width, $measured_height) = getimagesize($filename);
-          if ($measured_width == $width &&
-              $measured_height == $height) {
-            $this->images[$size] = (object) array(
-                'url' => $url,
-                'width' => $width,
-                'height' => $height
-            );
-          }
-        }
-      } else {
-
-        $this->images[$size] = (object) array(
+      $filename = ABSPATH . substr($url, strlen($home) + 1);
+      if (file_exists($filename)) {
+        list($measured_width, $measured_height) = getimagesize($filename);
+        if ($measured_width == $width &&
+            $measured_height == $height) {
+          $this->images[$size] = (object) array(
             'url' => $url,
             'width' => $width,
             'height' => $height
-        );
-
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
If the plugin "WP-Offload-S3" is installed, the attachments are stored at AWS S3 and are available either per S3 or via AWS Cloudfront and not necessarily hosted on the server being available at ABSPATH. 
In this case, file_exists() will check the wrong filepath here. 
In my PR i'm checking the hostname of the image URLs again the hostname of the wordpress installation and, if they are different, i just pass the information from wp_get_attachment_image_src(), which contains the full path to S3/Cloudfront, and renounce calls to file_exists() and getimagesize(). 

I reverted the first commit because i forgot to create a branch first.
